### PR TITLE
fix: Add style for a container that contains each content #9

### DIFF
--- a/src/components/Container/Container.module.css
+++ b/src/components/Container/Container.module.css
@@ -1,8 +1,7 @@
 .containerWrapper {
   width: 100vw;
   max-width: 1920px;
-  margin: auto;
-  margin-top: -100px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -31,61 +31,61 @@ const Home = () => {
 
   return (
     <>
-      <Container>
-        {/* SEO SECTION - DO NOT TOUCH */}
-        <Helmet>
-          <meta charSet="utf-8" />
-          <title>HOME PAGE</title>
-          <link rel="canonical" href="https://www.smatched.io/" />
-          <link rel="canonical" href="https://www.offerwallmonetization.com/" />
-        </Helmet>
+      {/* Container Cannot be applied before the background of the page! */}
+      {/* SEO SECTION - DO NOT TOUCH */}
+      <Helmet>
+        <meta charSet="utf-8" />
+        <title>HOME PAGE</title>
+        <link rel="canonical" href="https://www.smatched.io/" />
+        <link rel="canonical" href="https://www.offerwallmonetization.com/" />
+      </Helmet>
 
-        <div style={{ display: 'none' }}>
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{
-              __html: JSON.stringify(articleStructuredData),
-            }}
-          />
+      <div style={{ display: 'none' }}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(articleStructuredData),
+          }}
+        />
 
-          <h1>{articleStructuredData.headline}</h1>
-          <h3>
-            by{' '}
-            <a href={articleStructuredData.author.url}>
-              {articleStructuredData.author.name}
-            </a>{' '}
-            on {articleStructuredData.datePublished}
-          </h3>
+        <h1>{articleStructuredData.headline}</h1>
+        <h3>
+          by{' '}
+          <a href={articleStructuredData.author.url}>
+            {articleStructuredData.author.name}
+          </a>{' '}
+          on {articleStructuredData.datePublished}
+        </h3>
 
-          <img
-            style={{ width: '5em' }}
-            alt="https://json-ld.org/ - Website content released under a Creative Commons CC0 Public Domain Dedication except where an alternate is specified., CC0, via Wikimedia Commons"
-            src={articleStructuredData.image}
-          />
+        <img
+          style={{ width: '5em' }}
+          alt="https://json-ld.org/ - Website content released under a Creative Commons CC0 Public Domain Dedication except where an alternate is specified., CC0, via Wikimedia Commons"
+          src={articleStructuredData.image}
+        />
 
-          <p>{articleStructuredData.description}</p>
+        <p>{articleStructuredData.description}</p>
 
-          <p>Take a look at the source of this page and find the JSON-LD!</p>
-        </div>
+        <p>Take a look at the source of this page and find the JSON-LD!</p>
+      </div>
 
-        {/* END OF SEO SECTION */}
+      {/* END OF SEO SECTION */}
 
-        {/* First Home */}
+      {/* First Home */}
 
-        <div className="app">
-          <Hero
-            backgroundImage="../../images/backgroundImgs/Background1.png"
-            H1="<b>Boost Monetization.</b> Retain Users."
-            // H2="Retain Users."
-            H3="MONETIZE"
-            H4="Metered paywalls have an average conversion rate of just 0.36%. Smatched builds customized ‘earn to play’ offerwalls that boost monetization on your mobile app or website and helps you retain users by offering more choice."
-            src="../../images/hero/heroHome.png"
-            alt="Description for image 1"
-            width="647px"
-            height="605px"
-            showBot={true}
-          />
-          <Second
+      <div className="app">
+        <Hero
+          backgroundImage="../../images/backgroundImgs/Background1.png"
+          H1="<b>Boost Monetization.</b> Retain Users."
+          // H2="Retain Users."
+          H3="MONETIZE"
+          H4="Metered paywalls have an average conversion rate of just 0.36%. Smatched builds customized ‘earn to play’ offerwalls that boost monetization on your mobile app or website and helps you retain users by offering more choice."
+          src="../../images/hero/heroHome.png"
+          alt="Description for image 1"
+          width="647px"
+          height="605px"
+          showBot={true}
+        />
+        <Second
           backgroundColor="#1E1E1E"
           H2="Monetize provides an alternative Subscription Model"
           H3="Paywalls are a great revenue option for many businesses but unfortunately, making users pay means your revenue potential is capped. Businesses that offer more than one monetization model retain <b>50% more users</b>.</br></br>
@@ -94,15 +94,13 @@ const Home = () => {
           B2="Users earn rewards"
           B3="Users can use rewards as in-app</br>currency"
           B4="You increase revenue & retention"
-          width='150px'
+          width="150px"
           src1="../../images/second/secondHome1.svg"
           src2="../../images/second/secondHome2.svg"
           src3="../../images/second/secondHome3.svg"
           src4="../../images/second/secondHome4.svg"
-          
-          />
-        </div>
-      </Container>
+        />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
[Issue #9](https://github.com/davijaca/getmonetize/issues/9)
The Container can't contain the page's background, since it could leave a white space between the app and the edges of the viewport.

- I removed the Container component from the Home page since it is containing more than it should (the background).
- I removed the `margin-top: -100px` and added a `margin: 0 auto` to replace it.
- The `margin-top: -100px`, should be added to the first child of the page, to avoid the overlap from the navbar.

Now, The Container can be added to each component that builds the main parts of the page, to respect the same size and position. (it includes, the navbar and the footer of the page).

-PS.: I just realized that my prettier is set differently from yours, so the conflicts should be resumed to 1 quote and 2 quotes.
I added a prettier ignore to my editor to avoid this conflict for future merges.
